### PR TITLE
Don't run build workflow on versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,8 +1,6 @@
 name: build
 on:
   push:
-    tags:
-      - v*
     branches:
       - main
   pull_request:


### PR DESCRIPTION
This doesn't actually do any useful function, so don't bother running build/test on version... we already ran this on the merge into `main` and on PRs.