### PR TITLE
Add back 1 second buffer to config file tests to avoid flakiness

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,6 +15,7 @@ Vagrant.configure("2") do |config|
     cynb.vm.hostname = "cynb"
     cynb.vm.network "private_network", ip: "192.168.58.3"
   end
+
   # If we really need it, uncomment this...
   #config.vm.define "cync" do |cync|
     #cync.vm.hostname = "cync"

--- a/tests/features/tcp.feature
+++ b/tests/features/tcp.feature
@@ -23,6 +23,6 @@ Feature: send and receive TCP
         - 127.0.0.1:24568
       send-interval: 10ms
       """
-    And cyn is started with the config file
-    When I wait 1 second
+    When cyn is started with the config file
+    And I wait 1 second
     Then the stdout contains "hi"

--- a/tests/features/udp.feature
+++ b/tests/features/udp.feature
@@ -24,4 +24,5 @@ Feature: send and receive UDP
       send-interval: 10ms
       """
     When cyn is started with the config file
+    And I wait 1 second
     Then the stdout contains "hi"


### PR DESCRIPTION
A test failed due to the startup time being too quick, so put the 1 second buffer back...