### PR TITLE
Add mainProgram meta so nix can run it

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -11,4 +11,5 @@ buildGoApplication {
   src = ./.;
   subPackages = [ "cmd/cyn" ];
   modules = ./gomod2nix.toml;
+  meta.mainProgram = "cyn";
 }


### PR DESCRIPTION
The binary is `cyn` by default, but the package is `cynomys`.